### PR TITLE
Rework TravisCI build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitkeep

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ pipeline:
       - GOARCH=amd64
       - CGO_ENABLED=0
     commands:
-      - go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -o release/drone-passwordstate
+      - go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -o ./release/drone-passwordstate
 
   release:
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,8 +23,7 @@ pipeline:
       - GOARCH=amd64
       - CGO_ENABLED=0
     commands:
-      - mkdir -p ./release/linux/amd64
-      - go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -o ./release/linux/amd64/drone-passwordstate
+      - go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -o ./release/drone-passwordstate
 
   release:
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,8 @@ pipeline:
       - GOARCH=amd64
       - CGO_ENABLED=0
     commands:
-      - go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -o ./release/drone-passwordstate
+      - mkdir -p ./release/linux/amd64
+      - go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -o ./release/linux/amd64/drone-passwordstate
 
   release:
     image: plugins/docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
 
     - stage: release
       script:
+        - ls -la */
         - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
         - export REPO=$DOCKER_REPO
         - docker build -f Dockerfile -t $REPO:$TRAVIS_TAG -t $REPO:latest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ jobs:
         - GOARCH=amd64
         - CGO_ENABLED=0
       script:
-        - go build -v -ldflags "-X main.version=${TRAVIS_TAG}" -a -o ./release/drone-passwordstate
+        - mkdir -p ./release/linux/amd64
+        - go build -v -ldflags "-X main.version=${TRAVIS_TAG}" -a -o ./release/linux/amd64/drone-passwordstate
 
     - stage: release
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,17 @@ go:
 git:
   depth: 1
 
+env:
+  - GOOS=linux
+  - GOARCH=amd64
+
 install:
   - go get -u github.com/golang/dep/cmd/dep
   - dep ensure
   - dep status
 
 script:
-  - go build -v -ldflags "-X main.version=${TRAVIS_TAG}" -a -o ./drone-passwordstate
+  - go build -v -ldflags "-X main.version=${TRAVIS_TAG}" -a -o ./release/drone-passwordstate
 
 after_success:
   - test $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 sudo: required
 
+install: true
 language: go
 go:
   - "1.10.3"
+
+cache:
+  directories:
+    - release
+    - vendor
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,22 @@
-sudo: required
+sudo: false
 
-install: true
 language: go
 go:
-  - "1.10.3"
+  - '1.10.3'
 
-cache:
-  directories:
-    - release
-    - vendor
+git:
+  depth: 1
 
-services:
-  - docker
+install:
+  - go get -u github.com/golang/dep/cmd/dep
+  - dep ensure
+  - dep status
 
-jobs:
-  include:
-    - stage: restore
-      script:
-        - go get -u github.com/golang/dep/cmd/dep
-        - dep ensure
-        - dep status
+script:
+  - go build -v -ldflags "-X main.version=${TRAVIS_TAG}" -a -o ./drone-passwordstate
 
-    - stage: test
-      script:
-        - go vet ./...
-        - go test -cover ./...
-
-    - stage: build
-      env:
-        - GOOS=linux
-        - GOARCH=amd64
-        - CGO_ENABLED=0
-      script:
-        - mkdir -p ./release/linux/amd64
-        - go build -v -ldflags "-X main.version=${TRAVIS_TAG}" -a -o ./release/linux/amd64/drone-passwordstate
-
-    - stage: release
-      script:
-        - ls -la */
-        - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-        - export REPO=$DOCKER_REPO
-        - docker build -f Dockerfile -t $REPO:$TRAVIS_TAG -t $REPO:latest .
-        - docker push $REPO
-      if: tag IS present
+after_success:
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - export REPO=$DOCKER_REPO
+  - docker build -f Dockerfile -t $REPO:$TRAVIS_TAG -t $REPO:latest .
+  - docker push $REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ language: go
 go:
   - '1.10.3'
 
+env:
+  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+
 git:
   depth: 1
-
-env:
-  - GOOS=linux
-  - GOARCH=amd64
 
 install:
   - go get -u github.com/golang/dep/cmd/dep

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   - go build -v -ldflags "-X main.version=${TRAVIS_TAG}" -a -o ./drone-passwordstate
 
 after_success:
+  - test $TRAVIS_TAG
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - export REPO=$DOCKER_REPO
   - docker build -f Dockerfile -t $REPO:$TRAVIS_TAG -t $REPO:latest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
         - GOARCH=amd64
         - CGO_ENABLED=0
       script:
-        - go build -v -ldflags "-X main.version=${TRAVIS_TAG}" -a -o release/drone-passwordstate
+        - go build -v -ldflags "-X main.version=${TRAVIS_TAG}" -a -o ./release/drone-passwordstate
 
     - stage: release
       script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.7
-COPY ./release/linux/amd64 .
+ADD ./drone-passwordstate .
 
 ENTRYPOINT [ "./drone-passwordstate" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.7
-COPY ./release .
+COPY ./release/linux/amd64 .
 
 ENTRYPOINT [ "./drone-passwordstate" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.7
-ADD ./drone-passwordstate .
+COPY ./release .
 
 ENTRYPOINT [ "./drone-passwordstate" ]


### PR DESCRIPTION
The TravisCI CI job was rewritten to avoid using of stages, that make the pipeline more complex than needed, due to the fact there's no data persistence between the stages. In addition, the builds are much faster now.