### PR TITLE
Update information in README.md about Generic Fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pipeline:
     value_field: GenericField6
 ```
 
-However, please note, that "Generic Fields", even when renamed in Passwordstate, still have to be entered as "GenericField1", "GenericField2" for password retrieval to work.
+However, please note, that "Generic Fields", even when renamed in Passwordstate, still have to be entered as "GenericField1", "GenericField2" and so on for password retrieval to work.
 
 ### Using the plugin for Kubernetes secrets
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ pipeline:
     value_field: GenericField6
 ```
 
+However, please note, that "Generic Fields", even when renamed in Passwordstate, still have to be entered as "GenericField1", "GenericField2" for password retrieval to work.
+
 ### Using the plugin for Kubernetes secrets
 
 One of the most likely use case for the plugin would be combining it with [drone-helm plugin](https://github.com/ipedrazas/drone-helm), allowing you to deploy the secrets as part of the whole [Helm chart](https://github.com/kubernetes/helm). The following example illustrates the pipeline combining these two plugins:


### PR DESCRIPTION
Passwordstate API returns Generic Fields as "GenericFieldX" even if they are renamed in the Passwordstate GUI.

Adding a note that users wouldn't run into issues when using the renamed value for either key_field or value_field.